### PR TITLE
Update VisionClient.cfc (so it works without lucee)

### DIFF
--- a/models/VisionClient.cfc
+++ b/models/VisionClient.cfc
@@ -50,7 +50,9 @@ component hint="" accessors="true" singleton {
 	 */	
 	public string function sendRequest(	body ) {	
 	    var httpService = new http(); 
-		httpService.setEncodeUrl(false);
+	    if(structKeyExists(httpService, 'setEncodeUrl')) {
+	    	httpService.setEncodeUrl(false);
+	    }
 	    httpService.setMethod("POST"); 
 	    
 	    if(structKeyExists(arguments,'endpoint'))


### PR DESCRIPTION
http::setEncodeUrl() is a method only defined in Lucee. I had issues getting the code to run because of this. This fix makes it work in both.